### PR TITLE
Bugfixes and persistent undo/redo between rooms

### DIFF
--- a/Dialog/DoorConfigDialog.cpp
+++ b/Dialog/DoorConfigDialog.cpp
@@ -91,7 +91,7 @@ DoorConfigDialog::DoorConfigDialog(QWidget *parent, LevelComponents::Room *curre
     UpdateComboBoxEntitySet();
 
     // Initialize the entity list drop-down
-    for(unsigned int i = 1; i < sizeof(entities)/sizeof(entities[0]); ++i)
+    for(unsigned int i = 1; i < sizeof(entities) / sizeof(entities[0]); ++i)
     {
         EntityFilterTable->AddEntity(entities[i]);
     }
@@ -141,13 +141,13 @@ void DoorConfigDialog::UpdateCurrentDoorData()
 void DoorConfigDialog::StaticInitialization()
 {
     // Initialize the selections for the Door type
-    for(unsigned int i = 0; i < sizeof(DoortypeSetData)/sizeof(DoortypeSetData[0]); ++i)
+    for(unsigned int i = 0; i < sizeof(DoortypeSetData) / sizeof(DoortypeSetData[0]); ++i)
     {
         DoortypeSet << DoortypeSetData[i];
     }
 
     // Initialize the selections for the Entity name
-    for(unsigned int i = 0; i < sizeof(EntitynameSetData)/sizeof(EntitynameSetData[0]); ++i)
+    for(unsigned int i = 0; i < sizeof(EntitynameSetData) / sizeof(EntitynameSetData[0]); ++i)
     {
         EntitynameSet << EntitynameSetData[i];
     }
@@ -159,13 +159,13 @@ void DoorConfigDialog::StaticInitialization()
 void DoorConfigDialog::EntitySetsInitialization()
 {
     // Initialize all the entitysets
-    for(int i = 0; i < 90; ++i)
+    for(unsigned int i = 0; i < sizeof(entitiessets) / sizeof(entitiessets[0]); ++i)
     {
         entitiessets[i] = new LevelComponents::EntitySet(i, WL4Constants::UniversalSpritesPalette);
     }
 
     // Initialize all the Entity
-    for(int i = 0; i < 129; ++i)
+    for(unsigned int i = 0; i < sizeof(entities) / sizeof(entities[0]); ++i)
     {
         struct LevelComponents::EntitySetAndEntitylocalId tmpEntitysetAndEntitylocalId = LevelComponents::EntitySet::EntitySetFromEntityID(i);
         entities[i] = new LevelComponents::Entity(tmpEntitysetAndEntitylocalId.entitylocalId, i, entitiessets[tmpEntitysetAndEntitylocalId.entitysetId]);
@@ -550,13 +550,15 @@ void DoorConfigDialog::on_ComboBox_EntitySetID_currentIndexChanged(int index)
 /// </param>
 EntityFilterTableModel::EntityFilterTableModel(QWidget *_parent) : QStandardItemModel(_parent), parent(_parent)
 {
-    //TODO
+    // nothing
 }
 
+/// <summary>
+/// Perform cleanup for deconstruction of EntityFilterTableModel.
+/// </summary>
 EntityFilterTableModel::~EntityFilterTableModel()
 {
-    // TODO
-    for (auto& item : entities)
+    foreach(TableEntityItem item, entities)
     {
         // don't delete
         item.entity = NULL;
@@ -571,16 +573,12 @@ EntityFilterTableModel::~EntityFilterTableModel()
 /// </param>
 void EntityFilterTableModel::AddEntity(LevelComponents::Entity *entity)
 {
-    /*TableEntity item;
-    item.entity = entity;
-    item.entityName = DoorConfigDialog::EntitynameSetData[entity->GetEntityGlobalID()-1];
-    item.entityImage = */
     entities.push_back({
-                           entity,
-                           DoorConfigDialog::EntitynameSetData[entity->GetEntityGlobalID()-1],
-                           entity->Render(),
-                           true
-                       });
+        entity,
+        DoorConfigDialog::EntitynameSetData[entity->GetEntityGlobalID()-1],
+        entity->Render(),
+        true
+    });
 }
 
 /// <summary>

--- a/EditorWindow/MainGraphicsView.cpp
+++ b/EditorWindow/MainGraphicsView.cpp
@@ -35,25 +35,7 @@ void MainGraphicsView::mousePressEvent(QMouseEvent *event)
 
         if(editMode == Ui::LayerEditMode) // Change textmaps and layer graphic
         {
-            unsigned short selectedTile = singleton->GetTile16DockWidgetPtr()->GetSelectedTile();
-            if(selectedTile == 0xFFFF) return;
-            int selectedLayer = singleton->GetEditModeWidgetPtr()->GetEditModeParams().selectedLayer;
-            LevelComponents::Layer *layer = room->GetLayer(selectedLayer);
-            if(layer->IsEnabled() == false) return;
-            IsDrawing = true;
-            int selectedTileIndex = tileX + tileY * room->GetWidth();
-            if(layer->GetLayerData()[selectedTileIndex] == selectedTile) return;
-            struct OperationParams *params = new struct OperationParams();
-            params->type = ChangeTileOperation;
-            params->tileChangeParams.push_back(TileChangeParams::Create(
-                tileX,
-                tileY,
-                selectedLayer,
-                selectedTile,
-                layer->GetLayerData()[selectedTileIndex]
-            ));
-            ExecuteOperation(params);
-            // delete params; //shall we?
+            SetTile(tileX, tileY);
         }
         else if(editMode == Ui::DoorEditMode) // select a door
         {
@@ -107,7 +89,6 @@ DOOR_FOUND:     ;
             }
             singleton->RenderScreenElementsLayersUpdate((unsigned int) -1, SelectedEntityID);
         }
-        // TODO add more cases for other edit mode types
     }
 }
 
@@ -140,30 +121,45 @@ void MainGraphicsView::mouseMoveEvent(QMouseEvent *event)
 
         if((editMode == Ui::LayerEditMode) && IsDrawing) // Change textmaps and layer graphic
         {
-            unsigned short selectedTile = singleton->GetTile16DockWidgetPtr()->GetSelectedTile();
-            if(selectedTile == 0xFFFF) return;
-            int selectedLayer = singleton->GetEditModeWidgetPtr()->GetEditModeParams().selectedLayer;
-            LevelComponents::Layer *layer = room->GetLayer(selectedLayer);
-            if(layer->IsEnabled() == false) return;
-            int selectedTileIndex = tileX + tileY * room->GetWidth();
-            if(layer->GetLayerData()[selectedTileIndex] == selectedTile) return;
-            struct OperationParams *params = new struct OperationParams();
-            params->type = ChangeTileOperation;
-            params->tileChangeParams.push_back(TileChangeParams::Create(
-                tileX,
-                tileY,
-                selectedLayer,
-                selectedTile,
-                layer->GetLayerData()[selectedTileIndex]
-            ));
-            ExecuteOperation(params);
-            // delete params; //shall we?
+            SetTile(tileX, tileY);
         }
     }
     else
     {
         IsDrawing = false;
     }
+}
+
+/// <summary>
+/// This is a helper function for setting the tile at a tile position to the currently
+/// selected tile from the UI.
+/// </summary>
+/// <param name="tileX">
+/// The X position of the tile (unit: map16)
+/// </param>
+/// <param name="tileY">
+/// The Y position of the tile (unit: map16)
+/// </param>
+void MainGraphicsView::SetTile(int tileX, int tileY)
+{
+    LevelComponents::Room *room = singleton->GetCurrentRoom();
+    unsigned short selectedTile = singleton->GetTile16DockWidgetPtr()->GetSelectedTile();
+    if(selectedTile == 0xFFFF) return;
+    int selectedLayer = singleton->GetEditModeWidgetPtr()->GetEditModeParams().selectedLayer;
+    LevelComponents::Layer *layer = room->GetLayer(selectedLayer);
+    if(layer->IsEnabled() == false) return;
+    int selectedTileIndex = tileX + tileY * room->GetWidth();
+    if(layer->GetLayerData()[selectedTileIndex] == selectedTile) return;
+    struct OperationParams *params = new struct OperationParams();
+    params->type = ChangeTileOperation;
+    params->tileChangeParams.push_back(TileChangeParams::Create(
+        tileX,
+        tileY,
+        selectedLayer,
+        selectedTile,
+        layer->GetLayerData()[selectedTileIndex]
+    ));
+    ExecuteOperation(params);
 }
 
 /// <summary>

--- a/EditorWindow/MainGraphicsView.cpp
+++ b/EditorWindow/MainGraphicsView.cpp
@@ -35,6 +35,8 @@ void MainGraphicsView::mousePressEvent(QMouseEvent *event)
 
         if(editMode == Ui::LayerEditMode) // Change textmaps and layer graphic
         {
+            drawingTileX = tileX;
+            drawingTileY = tileY;
             SetTile(tileX, tileY);
         }
         else if(editMode == Ui::DoorEditMode) // select a door
@@ -108,25 +110,28 @@ void MainGraphicsView::mouseMoveEvent(QMouseEvent *event)
     unsigned int tileX = X / 32;
     unsigned int tileY = Y / 32;
 
-    if((event->x() > (this->width() - 4)) || (event->y() > (this->height() - 4)))
+    // If we have moved within the same tile, do nothing
+    if(tileX == (unsigned int) drawingTileX && tileY == (unsigned int) drawingTileY)
     {
-        IsDrawing = false;
         return;
     }
 
+    // Draw the new tile
     LevelComponents::Room *room = singleton->GetCurrentRoom();
     if(tileX < room->GetWidth() && tileY < room->GetHeight())
     {
         enum Ui::EditMode editMode = singleton->GetEditModeWidgetPtr()->GetEditModeParams().editMode;
 
-        if((editMode == Ui::LayerEditMode) && IsDrawing) // Change textmaps and layer graphic
+        if((editMode == Ui::LayerEditMode)) // Change textmaps and layer graphic
         {
+            drawingTileX = tileX;
+            drawingTileY = tileY;
             SetTile(tileX, tileY);
         }
     }
     else
     {
-        IsDrawing = false;
+        mouseReleaseEvent(event);
     }
 }
 
@@ -171,7 +176,8 @@ void MainGraphicsView::SetTile(int tileX, int tileY)
 void MainGraphicsView::mouseReleaseEvent(QMouseEvent *event)
 {
     (void) event;
-    IsDrawing = false;
+    drawingTileX = -1;
+    drawingTileY = -1;
 }
 
 /// <summary>

--- a/EditorWindow/MainGraphicsView.h
+++ b/EditorWindow/MainGraphicsView.h
@@ -23,6 +23,8 @@ private:
     int SelectedDoorID = -1;
     int SelectedEntityID = -1;
     bool IsDrawing = false;
+
+    void SetTile(int tileX, int tileY);
 };
 
 #endif // MAINGRAPHICSVIEW_H

--- a/EditorWindow/MainGraphicsView.h
+++ b/EditorWindow/MainGraphicsView.h
@@ -22,7 +22,8 @@ public:
 private:
     int SelectedDoorID = -1;
     int SelectedEntityID = -1;
-    bool IsDrawing = false;
+    int drawingTileX = -1;
+    int drawingTileY = -1;
 
     void SetTile(int tileX, int tileY);
 };

--- a/Operation.cpp
+++ b/Operation.cpp
@@ -141,6 +141,10 @@ void ResetUndoHistory()
 {
     for(unsigned int i = 0; i < 16; ++i)
     {
+        for(unsigned int j = 0; j < operationHistory[i].size(); ++j)
+        {
+            delete operationHistory[i][j];
+        }
         operationHistory[i].clear();
     }
     memset(operationIndex, 0, sizeof(operationIndex));

--- a/ROMUtils.cpp
+++ b/ROMUtils.cpp
@@ -95,7 +95,7 @@ namespace ROMUtils
                 while(1)
                 {
                     int ctrl = CurrentFile[address++];
-                    if(ctrl == 0)
+                    if(!ctrl)
                     {
                         break;
                     }
@@ -135,7 +135,7 @@ namespace ROMUtils
                 {
                     int ctrl = ((int) CurrentFile[address] << 8) | CurrentFile[address + 1];
                     address += 2; // offset + 2
-                    if(ctrl == 0)
+                    if(!ctrl)
                     {
                         break;
                     }
@@ -461,9 +461,11 @@ findspace:  int chunkAddr = FindSpaceInROM(TempFile, TempLength, startAddr, chun
 
         // Clean up heap data and return
         success = true;
-        goto noerr;
-error:  free(TempFile);
-noerr:  foreach(struct SaveData chunk, chunks)
+        if(0)
+        {
+error:      free(TempFile);
+        }
+        foreach(struct SaveData chunk, chunks)
         {
             if(chunk.ChunkType != SaveDataChunkType::NullType) free(chunk.data);
         }

--- a/WL4EditorWindow.cpp
+++ b/WL4EditorWindow.cpp
@@ -496,7 +496,7 @@ void WL4EditorWindow::on_loadLevelButton_clicked()
     // Deselect Door and Entity
     ui->graphicsView->DeselectDoorAndEntity();
 
-    // Load the first level and render the screen
+    // Load the selected level and render the screen
     ChooseLevelDialog tmpdialog(selectedLevel);
     if(tmpdialog.exec() == QDialog::Accepted)
     {
@@ -538,9 +538,6 @@ void WL4EditorWindow::on_roomDecreaseButton_clicked()
     Tile16SelecterWidget->SetTileset(tmpTilesetID);
     ResetEntitySetDockWidget();
     ResetCameraControlDockWidget();
-
-    // Set program control changes
-    ResetUndoHistory();
 }
 
 /// <summary>
@@ -562,9 +559,6 @@ void WL4EditorWindow::on_roomIncreaseButton_clicked()
     Tile16SelecterWidget->SetTileset(tmpTilesetID);
     ResetEntitySetDockWidget();
     ResetCameraControlDockWidget();
-
-    // Set program control changes
-    ResetUndoHistory();
 }
 
 /// <summary>


### PR DESCRIPTION
- Feature: undo/redo persists between rooms now
- Fix memory corruption in DoorConfigDialog::EntitySetsInitialization()
- Fix memory leak in Operation::ResetUndoHistory()