### PR TITLE
Move entity and doors with the arrow keys

### DIFF
--- a/EditorWindow/MainGraphicsView.cpp
+++ b/EditorWindow/MainGraphicsView.cpp
@@ -229,22 +229,28 @@ void MainGraphicsView::keyPressEvent(QKeyEvent *event)
             case Qt::Key_Left ... Qt::Key_Down:
             {
                 LevelComponents::Room* currentRoom=singleton->GetCurrentRoom();
+
+                //The new positions
                 int px=currentRoom->GetEntityX(SelectedEntityID);
                 int py=currentRoom->GetEntityY(SelectedEntityID);
                 if (event->key() == Qt::Key_Left)
                 {
-                    currentRoom->SetEntityPosition(px-1,py,SelectedEntityID);
+                    px=px-1;
                 } else if (event->key() == Qt::Key_Right)
                 {
-                    currentRoom->SetEntityPosition(px+1,py,SelectedEntityID);
+                    px=px+1;
                 } else if (event->key() == Qt::Key_Up)
                 {
-                    currentRoom->SetEntityPosition(px,py-1,SelectedEntityID);
+                    py=py-1;
                 } else if (event->key() == Qt::Key_Down)
                 {
-                    currentRoom->SetEntityPosition(px,py+1,SelectedEntityID);
+                    py=py+1;
                 }
-                singleton->RenderScreenElementsLayersUpdate((unsigned int) -1, SelectedEntityID);
+
+                if (currentRoom->IsNewEntityPositionInsideRoom(px,py)) {
+                    currentRoom->SetEntityPosition(px,py,SelectedEntityID);
+                    singleton->RenderScreenElementsLayersUpdate((unsigned int) -1, SelectedEntityID);
+                }
                 break;
             }
         }
@@ -263,25 +269,36 @@ void MainGraphicsView::keyPressEvent(QKeyEvent *event)
                 break;
             //Move selected door when a direction key is pressed
             case Qt::Key_Left ... Qt::Key_Down:
-                LevelComponents::Door* selectedDoor=singleton->GetCurrentRoom()->GetDoor(SelectedDoorID);
+                LevelComponents::Room* currentRoom=singleton->GetCurrentRoom();
+                LevelComponents::Door* selectedDoor=currentRoom->GetDoor(SelectedDoorID);
+
+                //The new positions
                 int px1=selectedDoor->GetX1();
                 int py1=selectedDoor->GetY1();
                 int px2=selectedDoor->GetX2();
                 int py2=selectedDoor->GetY2();
                 if (event->key() == Qt::Key_Left)
                 {
-                    selectedDoor->SetDoorPlace(px1-1,px2-1,py1,py2);
+                    px1=px1-1;
+                    px2=px2-1;
                 } else if (event->key() == Qt::Key_Right)
                 {
-                    selectedDoor->SetDoorPlace(px1+1,px2+1,py1,py2);
+                    px1=px1+1;
+                    px2=px2+1;
                 } else if (event->key() == Qt::Key_Up)
                 {
-                    selectedDoor->SetDoorPlace(px1,px2,py1-1,py2-1);
+                    py1=py1-1;
+                    py2=py2-1;
                 } else if (event->key() == Qt::Key_Down)
                 {
-                    selectedDoor->SetDoorPlace(px1,px2,py1+1,py2+1);
+                    py1=py1+1;
+                    py2=py2+1;
+
                 }
-                singleton->RenderScreenElementsLayersUpdate((unsigned int) SelectedDoorID, -1);
+                if (currentRoom->IsNewDoorPositionInsideRoom(px1,px2,py1,py2)) {
+                   selectedDoor->SetDoorPlace(px1,px2,py1,py2);
+                   singleton->RenderScreenElementsLayersUpdate((unsigned int) SelectedDoorID, -1);
+                }
             break;
         }
     }

--- a/EditorWindow/MainGraphicsView.cpp
+++ b/EditorWindow/MainGraphicsView.cpp
@@ -208,24 +208,82 @@ void MainGraphicsView::mouseReleaseEvent(QMouseEvent *event)
 /// </param>
 void MainGraphicsView::keyPressEvent(QKeyEvent *event)
 {
-    // Delete selected entity if BSP or DEL is pressed
-    if((SelectedEntityID != -1) && ((event->key() == Qt::Key_Backspace) || (event->key() == Qt::Key_Delete)))
+    //If an entity is selected
+    if(SelectedEntityID != -1)
     {
-        singleton->DeleteEntity(SelectedEntityID);
-        SelectedEntityID = -1;
-        singleton->RenderScreenElementsLayersUpdate((unsigned int) -1, -1);
-        int difficulty = singleton->GetEditModeWidgetPtr()->GetEditModeParams().seleteddifficulty;
-        singleton->GetCurrentRoom()->SetEntityListDirty(difficulty, true);
-        singleton->SetUnsavedChanges(true);
-    }
-
-    // Delete selected door if BSP or DEL is pressed
-    else if((SelectedDoorID != -1) && ((event->key() == Qt::Key_Backspace) || (event->key() == Qt::Key_Delete)))
+        switch (event->key())
+        {
+            // Delete selected entity if BSP or DEL is pressed
+            case Qt::Key_Backspace:
+            case Qt::Key_Delete:
+            {
+                singleton->DeleteEntity(SelectedEntityID);
+                SelectedEntityID = -1;
+                singleton->RenderScreenElementsLayersUpdate((unsigned int) -1, -1);
+                int difficulty = singleton->GetEditModeWidgetPtr()->GetEditModeParams().seleteddifficulty;
+                singleton->GetCurrentRoom()->SetEntityListDirty(difficulty, true);
+                singleton->SetUnsavedChanges(true);
+                break;
+            }
+            //Move selected entity when a direction key is pressed
+            case Qt::Key_Left ... Qt::Key_Down:
+            {
+                LevelComponents::Room* currentRoom=singleton->GetCurrentRoom();
+                int px=currentRoom->GetEntityX(SelectedEntityID);
+                int py=currentRoom->GetEntityY(SelectedEntityID);
+                if (event->key() == Qt::Key_Left)
+                {
+                    currentRoom->SetEntityPosition(px-1,py,SelectedEntityID);
+                } else if (event->key() == Qt::Key_Right)
+                {
+                    currentRoom->SetEntityPosition(px+1,py,SelectedEntityID);
+                } else if (event->key() == Qt::Key_Up)
+                {
+                    currentRoom->SetEntityPosition(px,py-1,SelectedEntityID);
+                } else if (event->key() == Qt::Key_Down)
+                {
+                    currentRoom->SetEntityPosition(px,py+1,SelectedEntityID);
+                }
+                singleton->RenderScreenElementsLayersUpdate((unsigned int) -1, SelectedEntityID);
+                break;
+            }
+        }
+    //If a door is selected
+    } else if(SelectedDoorID != -1)
     {
-        singleton->DeleteDoor(singleton->GetCurrentRoom()->GetDoor(SelectedDoorID)->GetGlobalDoorID());
-        SelectedDoorID = -1;
-        singleton->RenderScreenElementsLayersUpdate((unsigned int) -1, -1);
-        singleton->SetUnsavedChanges(true);
+        switch (event->key())
+        {
+        // Delete selected door if BSP or DEL is pressed
+            case Qt::Key_Backspace:
+            case Qt::Key_Delete:
+                singleton->DeleteDoor(singleton->GetCurrentRoom()->GetDoor(SelectedDoorID)->GetGlobalDoorID());
+                SelectedDoorID = -1;
+                singleton->RenderScreenElementsLayersUpdate((unsigned int) -1, -1);
+                singleton->SetUnsavedChanges(true);
+                break;
+            //Move selected door when a direction key is pressed
+            case Qt::Key_Left ... Qt::Key_Down:
+                LevelComponents::Door* selectedDoor=singleton->GetCurrentRoom()->GetDoor(SelectedDoorID);
+                int px1=selectedDoor->GetX1();
+                int py1=selectedDoor->GetY1();
+                int px2=selectedDoor->GetX2();
+                int py2=selectedDoor->GetY2();
+                if (event->key() == Qt::Key_Left)
+                {
+                    selectedDoor->SetDoorPlace(px1-1,px2-1,py1,py2);
+                } else if (event->key() == Qt::Key_Right)
+                {
+                    selectedDoor->SetDoorPlace(px1+1,px2+1,py1,py2);
+                } else if (event->key() == Qt::Key_Up)
+                {
+                    selectedDoor->SetDoorPlace(px1,px2,py1-1,py2-1);
+                } else if (event->key() == Qt::Key_Down)
+                {
+                    selectedDoor->SetDoorPlace(px1,px2,py1+1,py2+1);
+                }
+                singleton->RenderScreenElementsLayersUpdate((unsigned int) SelectedDoorID, -1);
+            break;
+        }
     }
 }
 

--- a/LevelComponents/Room.cpp
+++ b/LevelComponents/Room.cpp
@@ -1006,7 +1006,7 @@ namespace LevelComponents
     /// </returns>
     void Room::SetEntityPosition(int XPos, int YPos, int index)
     {
-        if(EntityList[currentDifficulty].size() == (int) 47) return false;
+        if(EntityList[currentDifficulty].size() == (int) 47) return;
         EntityList[currentDifficulty].at(index).XPos=XPos;
         EntityList[currentDifficulty].at(index).YPos=YPos;
         return;
@@ -1023,7 +1023,7 @@ namespace LevelComponents
     int Room::GetEntityX(int index)
     {
         if(EntityList[currentDifficulty].size() == (int) 47) return false;
-        return EntityList[currentDifficulty].at(index).XPos;;
+        return EntityList[currentDifficulty].at(index).XPos;
     }
 
     /// <summary>
@@ -1037,7 +1037,7 @@ namespace LevelComponents
     int Room::GetEntityY(int index)
     {
         if(EntityList[currentDifficulty].size() == (int) 47) return false;
-        return EntityList[currentDifficulty].at(index).YPos;;
+        return EntityList[currentDifficulty].at(index).YPos;
     }
 
     /// <summary>
@@ -1108,4 +1108,51 @@ namespace LevelComponents
     {
         memcpy(CameraControlRecords[index], &limitator_data, sizeof(__CameraControlRecord));
     }
+
+    /// <summary>
+    /// Check if the new Door position is in the Room.
+    /// </summary>
+    /// <param name="x1">
+    /// The new position x1 of the door
+    /// </param>
+    /// <param name="x2">
+    /// The new position x2 of the door
+    /// </param>
+    /// <param name="y1">
+    /// The new position y1 of the door
+    /// </param>
+    /// /// <param name="y2">
+    /// The new position y2 of the door
+    /// </param>
+    /// <returns>
+    /// True if the new Door position is inside the Room
+    /// </returns>
+    bool Room::IsNewDoorPositionInsideRoom(int x1, int x2, int y1, int y2) {
+        if (x1 >= 0 && x2 < this->GetWidth() && y1 >=0 && y2 < this->GetHeight()) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Check if the new Entity position is in the Room.
+    /// </summary>
+    /// <param name="x">
+    /// The new position x of the Entity
+    /// </param>
+    /// <param name="y">
+    /// The new position y of the Entity
+    /// </param>
+    /// <returns>
+    /// True if the new Entity position is inside the Room
+    /// </returns>
+    bool Room::IsNewEntityPositionInsideRoom(int x, int y) {
+        if (x >= 0 && x < this->GetWidth() && y >=0 && y < this->GetHeight()) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
 }

--- a/LevelComponents/Room.cpp
+++ b/LevelComponents/Room.cpp
@@ -991,6 +991,56 @@ namespace LevelComponents
     }
 
     /// <summary>
+    /// Move an Entity from the current Entity List.
+    /// </summary>
+    /// <param name="XPos">
+    /// The new X position of the entity.
+    /// </param>
+    /// <param name="YPos">
+    /// The new Y position of the entity.
+    /// </param>
+    /// <param name="index">
+    /// The index of the Entity record in EntityList[currentDifficulty], count from 0.
+    /// <returns>
+    /// Always true (?)
+    /// </returns>
+    void Room::SetEntityPosition(int XPos, int YPos, int index)
+    {
+        if(EntityList[currentDifficulty].size() == (int) 47) return false;
+        EntityList[currentDifficulty].at(index).XPos=XPos;
+        EntityList[currentDifficulty].at(index).YPos=YPos;
+        return;
+    }
+
+    /// <summary>
+    /// Get the x position of an Entity from the current Entity List.
+    /// </summary>
+    /// <param name="index">
+    /// The index of the Entity record in EntityList[currentDifficulty], count from 0.
+    /// <returns>
+    /// The x position
+    /// </returns>
+    int Room::GetEntityX(int index)
+    {
+        if(EntityList[currentDifficulty].size() == (int) 47) return false;
+        return EntityList[currentDifficulty].at(index).XPos;;
+    }
+
+    /// <summary>
+    /// Get the y position of an Entity from the current Entity List.
+    /// </summary>
+    /// <param name="index">
+    /// The index of the Entity record in EntityList[currentDifficulty], count from 0.
+    /// <returns>
+    /// The y position
+    /// </returns>
+    int Room::GetEntityY(int index)
+    {
+        if(EntityList[currentDifficulty].size() == (int) 47) return false;
+        return EntityList[currentDifficulty].at(index).YPos;;
+    }
+
+    /// <summary>
     /// Delete an Entity from a Entity List.
     /// </summary>
     /// <param name="index">

--- a/LevelComponents/Room.h
+++ b/LevelComponents/Room.h
@@ -226,6 +226,8 @@ namespace LevelComponents
         void GetSaveChunks(QVector<ROMUtils::SaveData> &chunks, ROMUtils::SaveData *headerChunk, ROMUtils::SaveData *cameraPointerTableChunk, unsigned int *cameraPointerTableIndex);
         QGraphicsScene *RenderGraphicsScene(QGraphicsScene *scene, struct RenderUpdateParams *renderParams);
         void SetCameraLimitator(int index, __CameraControlRecord limitator_data);
+        bool IsNewDoorPositionInsideRoom(int x1, int x2, int y1, int y2);
+        bool IsNewEntityPositionInsideRoom(int x, int y);
     };
 }
 

--- a/LevelComponents/Room.h
+++ b/LevelComponents/Room.h
@@ -175,6 +175,8 @@ namespace LevelComponents
         unsigned int GetRoomID() { return RoomID; }
         Tileset *GetTileset() { return tileset; }
         int GetTilesetID() { return RoomHeader.TilesetID; }
+        int GetEntityX(int index);
+        int GetEntityY(int index);
         bool IsBGLayerAutoScrollEnabled() { return RoomHeader.Layer3Scrolling == '\x07'; }
         bool IsBGLayerEnabled() { return RoomHeader.Layer3MappingType; }
         bool IsCameraBoundaryDirty() { return CameraBoundaryDirty; }
@@ -215,6 +217,7 @@ namespace LevelComponents
         void SetLayerDataPtr(int LayerNum, int dataPtr);
         void SetLayerPriorityAndAlphaAttributes(int layerPriorityAndAlphaAttr);
         void SetTileset(Tileset *newtileset, int tilesetID) { tileset = newtileset; RoomHeader.TilesetID = (unsigned char) tilesetID; }
+        void SetEntityPosition(int XPos, int YPos, int index);
 
         // Functions
         void AddCameraLimitator();


### PR DESCRIPTION
Pretty much self-explanatory.
When an entity or a door is selected, it can be moved with the arrow keys.
The move should respect the room boundaries.