### PR TITLE
Fix a bug when a door is already selected

### DIFF
--- a/EditorWindow/MainGraphicsView.h
+++ b/EditorWindow/MainGraphicsView.h
@@ -13,6 +13,7 @@ class MainGraphicsView : public QGraphicsView
 public:
     MainGraphicsView(QWidget *param) : QGraphicsView(param) {}
     void mousePressEvent(QMouseEvent *event);
+    void mouseDoubleClickEvent(QMouseEvent *event);
     void mouseMoveEvent(QMouseEvent *event);
     void mouseReleaseEvent(QMouseEvent *event);
     void keyPressEvent(QKeyEvent *event);

--- a/README.md
+++ b/README.md
@@ -12,5 +12,3 @@ And also, our Discord community will be the first place for exchanging and shari
 
 * Discord https://discord.gg/EQ6JhvP
 * Level sharing website : https://weirdprogramming.github.io/WarioLand4HackRepository/
-
-(to ssp uncomment the remove section in tileset.cpp to test the save event table feature (you should see a change at 58DDBC in the ROM file))


### PR DESCRIPTION
This commit fix a bug when a door is already selected (dialog now show only with doubleclick)