### PR TITLE
Ctrl+Left click shortcut to destination door and a bugfix

### DIFF
--- a/EditorWindow/MainGraphicsView.cpp
+++ b/EditorWindow/MainGraphicsView.cpp
@@ -147,6 +147,31 @@ void MainGraphicsView::mousePressEvent(QMouseEvent *event)
                     bool b4 = doorsInRoom[i].y2 >= (int) tileY;
                     if (b1 && b2 && b3 && b4) {
 
+                        // Ctrl+LeftClick: navigate to the destination door
+                        if ((event->button() == Qt::LeftButton) && (event->modifiers() & Qt::ControlModifier))
+                        {
+                            unsigned char destGlobalID = doorsInRoom[i].DestinationDoorGlobalID;
+                            if (destGlobalID != 0) // not the portal door
+                            {
+                                auto destDoor = singleton->GetCurrentLevel()->GetDoorListRef().GetDoor(destGlobalID);
+                                int destRoomID = destDoor.RoomID;
+                                if (destRoomID != room->GetRoomID()) // not self-pointing
+                                {
+                                    singleton->SetCurrentRoomId(destRoomID, false);
+                                }
+                                unsigned char destLocalID =
+                                    singleton->GetCurrentLevel()->GetDoorListRef().GetLocalIDByGlobalID(destGlobalID);
+                                SelectedDoorID = destLocalID;
+                                singleton->GetCurrentRoom()->SetCurrentEntitySet(destDoor.EntitySetID);
+                                singleton->ResetEntitySetDockWidget();
+                                holdingEntityOrDoor = true;
+                                objectInitialX = destDoor.x1;
+                                objectInitialY = destDoor.y1;
+                                singleton->RenderScreenElementsLayersUpdate((unsigned int) SelectedDoorID, -1);
+                            }
+                            return;
+                        }
+
                         // If the door that was clicked was not already selected, then select it
                         SelectedDoorID = i;
                         // Let the Entityset change with the last selected Door

--- a/Operation.cpp
+++ b/Operation.cpp
@@ -161,8 +161,8 @@ void PerformOperation(struct OperationParams *operation)
 
         if (dm->objectID != -1 && curDoor.DoorTypeByte)
         {
-            LevelComponents::Room *currentRoom = singleton->GetCurrentRoom();
-            if (currentRoom->IsNewDoorPositionInsideRoom(dm->nextPositionX, dm->nextPositionX + deltaX, dm->nextPositionY, dm->nextPositionY + deltaY))
+            LevelComponents::Room *doorRoom = singleton->GetCurrentLevel()->GetRooms()[dm->roomID];
+            if (doorRoom->IsNewDoorPositionInsideRoom(dm->nextPositionX, dm->nextPositionX + deltaX, dm->nextPositionY, dm->nextPositionY + deltaY))
             {
                 tmpDoorVec.SetDoorPlace(globalDoorId,
                                          dm->nextPositionX, dm->nextPositionX + deltaX,
@@ -518,8 +518,8 @@ void BackTrackOperation(struct OperationParams *operation)
 
         if (dm->objectID != -1 && curDoor.DoorTypeByte)
         {
-            LevelComponents::Room *currentRoom = singleton->GetCurrentRoom();
-            if (currentRoom->IsNewDoorPositionInsideRoom(dm->previousPositionX, dm->previousPositionX + deltaX, dm->previousPositionY, dm->previousPositionY + deltaY))
+            LevelComponents::Room *doorRoom = singleton->GetCurrentLevel()->GetRooms()[dm->roomID];
+            if (doorRoom->IsNewDoorPositionInsideRoom(dm->previousPositionX, dm->previousPositionX + deltaX, dm->previousPositionY, dm->previousPositionY + deltaY))
             {
                 tmpDoorVec.SetDoorPlace(globalDoorId,
                                          dm->previousPositionX, dm->previousPositionX + deltaX,


### PR DESCRIPTION
Support ctrl+left click to go to the destination door of a door in door editing mode
Fix move a door in Room 1, go to Room 2 and undo the previous step using Ctrl + Z, then go back to Room 1, the door with position change history does not return to its original position. (introduced from the previous PR #455 
Close #218 
