### PR TITLE
palettes serialization logic changes in Graphic Manager

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
         os: [windows-latest, macOS-latest, ubuntu-latest]
     steps:
       - name: Download Submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
           
@@ -31,7 +31,7 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
-          version: 6.4.2
+          version: 6.10.3
 
       - name: Setup MSVC environment
         if: startsWith(matrix.os, 'windows')

--- a/AssortedGraphicUtils.cpp
+++ b/AssortedGraphicUtils.cpp
@@ -268,7 +268,7 @@ QVector<struct AssortedGraphicUtils::AssortedGraphicEntryItem> AssortedGraphicUt
             // TODO: add validation check logic for each sub chunk
 
             // Extract Data from Infos
-            ExtractDataFromEntryInfo_v1(entry);
+            ExtractDataFromEntryInfo_v2(entry);
 
             assortedGraphicEntries.append(entry);
         }
@@ -282,7 +282,7 @@ QVector<struct AssortedGraphicUtils::AssortedGraphicEntryItem> AssortedGraphicUt
 /// <param name="entry">
 /// The struct data saves the info of a graphic.
 /// </param>
-void AssortedGraphicUtils::ExtractDataFromEntryInfo_v1(AssortedGraphicEntryItem &entry)
+void AssortedGraphicUtils::ExtractDataFromEntryInfo_v2(AssortedGraphicEntryItem &entry)
 {
     // palettes
     for (int i = 0; i < 16; ++i)

--- a/AssortedGraphicUtils.cpp
+++ b/AssortedGraphicUtils.cpp
@@ -2,8 +2,8 @@
 #include "LevelComponents/Layer.h"
 #include "WL4EditorWindow.h"
 
-#define AssortedGraphic_CHUNK_VERSION 0
-#define AssortedGraphic_FIELD_COUNT 14
+#define AssortedGraphic_CHUNK_VERSION 1
+#define AssortedGraphic_FIELD_COUNT 13
 
 extern WL4EditorWindow *singleton;
 
@@ -11,7 +11,7 @@ extern WL4EditorWindow *singleton;
 /// Upgrade the format of a assorted graphic list chunk by one version.
 /// </summary>
 /// <remarks>
-/// Version 0:
+/// Version 0 (14 fields per entry):
 ///   Semicolon-delimited:
 ///      0: TileDataAddress         (hex string)
 ///      1: TileDataSizeInByte       (hex string)
@@ -27,6 +27,22 @@ extern WL4EditorWindow *singleton;
 ///     11: PaletteRAMOffsetNum     (hex string)
 ///     12: optionalGraphicWidth    (hex string)
 ///     13: optionalGraphicHeight   (hex string)
+///
+/// Version 1 (13 fields per entry):
+///   Semicolon-delimited:
+///      0: TileDataAddress         (hex string)
+///      1: TileDataSizeInByte       (hex string)
+///      2: TileDataRAMOffsetNum    (hex string)
+///      3: TileDataCompressType    (hex string)
+///      4: TileDataName            (ascii string, may not contain a semicolon)
+///      5: MappingDataAddress      (hex string)
+///      6: MappingDataSizeInByte    (hex string)
+///      7: MappingDataCompressType (hex string)
+///      8: MappingDataName         (ascii string, may not contain a semicolon)
+///      9: optionalPaletteAddress  (hex string)
+///     10: PaletteSlotIDs          (comma-separated hex, e.g. "1,3,5")
+///     11: optionalGraphicWidth    (hex string)
+///     12: optionalGraphicHeight   (hex string)
 /// </remarks>
 /// <param name="contents">
 /// The assorted graphic list chunk contents to upgrade.
@@ -42,8 +58,44 @@ static QString UpgradeAssortedGraphicListContents(QString contents, int version)
     switch(version)
     {
         case 0:
-            // TODO implement when there are new versions
-            break;
+        {
+            // Version 0 -> 1: Convert PaletteNum (field 10) + PaletteRAMOffsetNum (field 11)
+            // into PaletteSlotIDs comma-separated hex (new field 10).
+            // Fields 12,13 (optionalGraphicWidth, optionalGraphicHeight) shift to 11,12.
+            // Total fields per entry goes from 14 to 13.
+            QStringList tuples = contents.split(";");
+            if (tuples.count() % 14 != 0) return contents; // corrupted, leave as-is
+
+            QStringList newTuples;
+            for (int i = 0; i < tuples.count(); i += 14)
+            {
+                // Fields 0-9 stay the same
+                for (int j = 0; j < 10; j++)
+                    newTuples.append(tuples[i + j]);
+
+                // Convert field 10 (PaletteNum) and field 11 (PaletteRAMOffsetNum)
+                // into comma-separated hex palette slot IDs
+                bool ok1, ok2;
+                unsigned int palNum = tuples[i + 10].toUInt(&ok1, 16);
+                unsigned int palOffset = tuples[i + 11].toUInt(&ok2, 16);
+                QString slotIDs;
+                if (ok1 && ok2)
+                {
+                    for (unsigned int k = 0; k < palNum && (k + palOffset) < 16; k++)
+                    {
+                        if (k > 0) slotIDs += ",";
+                        slotIDs += QString::number(k + palOffset, 16);
+                    }
+                }
+                if (slotIDs.isEmpty()) slotIDs = "0";
+                newTuples.append(slotIDs);
+
+                // Fields 12,13 become 11,12
+                newTuples.append(tuples[i + 12]); // optionalGraphicWidth
+                newTuples.append(tuples[i + 13]); // optionalGraphicHeight
+            }
+            return newTuples.join(";");
+        }
     }
     return contents;
 }
@@ -60,23 +112,32 @@ static QString UpgradeAssortedGraphicListContents(QString contents, int version)
 /// </returns>
 static struct AssortedGraphicUtils::AssortedGraphicEntryItem DeserializeAssortedGraphicMetadata(QStringList assortedgraphicTuples)
 {
-    struct AssortedGraphicUtils::AssortedGraphicEntryItem entry
+    struct AssortedGraphicUtils::AssortedGraphicEntryItem entry;
+    entry.TileDataAddress = assortedgraphicTuples[0].toUInt(Q_NULLPTR, 16); // TileDataAddress
+    entry.TileDataSizeInByte = assortedgraphicTuples[1].toUInt(Q_NULLPTR, 16); // TileDataSizeInByte
+    entry.TileDataRAMOffsetNum = assortedgraphicTuples[2].toUInt(Q_NULLPTR, 16); // TileDataRAMOffsetNum
+    entry.TileDataType = static_cast<enum AssortedGraphicUtils::AssortedGraphicTileDataType>(assortedgraphicTuples[3].toUInt(Q_NULLPTR, 16)); // TileDataCompressType
+    entry.TileDataName = assortedgraphicTuples[4]; // TileDataName
+    entry.MappingDataAddress = assortedgraphicTuples[5].toUInt(Q_NULLPTR, 16); // MappingDataAddress
+    entry.MappingDataSizeAfterCompressionInByte = assortedgraphicTuples[6].toUInt(Q_NULLPTR, 16); // MappingDataSizeInByte
+    entry.MappingDataCompressType = static_cast<enum AssortedGraphicUtils::AssortedGraphicMappingDataCompressionType>(assortedgraphicTuples[7].toUInt(Q_NULLPTR, 16)); // MappingDataCompressType
+    entry.MappingDataName = assortedgraphicTuples[8]; // MappingDataName
+    entry.PaletteAddress = assortedgraphicTuples[9].toUInt(Q_NULLPTR, 16); // optionalPaletteAddress
+
+    // Parse PaletteSlotIDs (comma-separated hex, e.g. "1,3,5")
+    QStringList slotIDStrings = assortedgraphicTuples[10].split(",", Qt::SkipEmptyParts);
+    for (const QString &s : slotIDStrings)
     {
-        assortedgraphicTuples[0].toUInt(Q_NULLPTR, 16), // TileDataAddress
-        assortedgraphicTuples[1].toUInt(Q_NULLPTR, 16), // TileDataSizeInByte
-        assortedgraphicTuples[2].toUInt(Q_NULLPTR, 16), // TileDataRAMOffsetNum
-        static_cast<enum AssortedGraphicUtils::AssortedGraphicTileDataType>(assortedgraphicTuples[3].toUInt(Q_NULLPTR, 16)), // TileDataCompressType
-        assortedgraphicTuples[4], // TileDataName
-        assortedgraphicTuples[5].toUInt(Q_NULLPTR, 16), // MappingDataAddress
-        assortedgraphicTuples[6].toUInt(Q_NULLPTR, 16), // MappingDataSizeInByte
-        static_cast<enum AssortedGraphicUtils::AssortedGraphicMappingDataCompressionType>(assortedgraphicTuples[7].toUInt(Q_NULLPTR, 16)), // MappingDataCompressType
-        assortedgraphicTuples[8], // MappingDataName
-        assortedgraphicTuples[9].toUInt(Q_NULLPTR, 16), // optionalPaletteAddress
-        assortedgraphicTuples[10].toUInt(Q_NULLPTR, 16), // PaletteNum
-        assortedgraphicTuples[11].toUInt(Q_NULLPTR, 16), // PaletteRAMOffsetNum
-        assortedgraphicTuples[12].toUInt(Q_NULLPTR, 16), // optionalGraphicWidth
-        assortedgraphicTuples[13].toUInt(Q_NULLPTR, 16), // optionalGraphicHeight
-    };
+        bool ok;
+        unsigned int slotId = s.toUInt(&ok, 16);
+        if (ok && slotId < 16)
+            entry.PaletteSlotIDs.push_back(slotId);
+    }
+    if (entry.PaletteSlotIDs.isEmpty())
+        entry.PaletteSlotIDs.push_back(0); // fallback
+
+    entry.optionalGraphicWidth = assortedgraphicTuples[11].toUInt(Q_NULLPTR, 16); // optionalGraphicWidth
+    entry.optionalGraphicHeight = assortedgraphicTuples[12].toUInt(Q_NULLPTR, 16); // optionalGraphicHeight
     return entry;
 }
 
@@ -102,8 +163,17 @@ static QString SerializeAssortedGraphicMetadata(const struct AssortedGraphicUtil
     ret += QString::number(assortedGraphicMetadata.MappingDataCompressType, 16) + ";";
     ret += assortedGraphicMetadata.MappingDataName + ";";
     ret += QString::number(assortedGraphicMetadata.PaletteAddress, 16) + ";";
-    ret += QString::number(assortedGraphicMetadata.PaletteNum, 16) + ";";
-    ret += QString::number(assortedGraphicMetadata.PaletteRAMOffsetNum, 16) + ";";
+
+    // Serialize PaletteSlotIDs as comma-separated hex
+    QString slotIDs;
+    for (int i = 0; i < assortedGraphicMetadata.PaletteSlotIDs.size(); i++)
+    {
+        if (i > 0) slotIDs += ",";
+        slotIDs += QString::number(assortedGraphicMetadata.PaletteSlotIDs[i], 16);
+    }
+    if (slotIDs.isEmpty()) slotIDs = "0";
+    ret += slotIDs + ";";
+
     ret += QString::number(assortedGraphicMetadata.optionalGraphicWidth, 16) + ";";
     ret += QString::number(assortedGraphicMetadata.optionalGraphicHeight, 16);
 
@@ -224,14 +294,22 @@ void AssortedGraphicUtils::ExtractDataFromEntryInfo_v1(AssortedGraphicEntryItem 
         for (int j = 0; j < 16; ++j) // (re-)initialization
             entry.palettes[i].push_back(QColor(0, 0, 0, 0xFF).rgba());
     }
-    for (int i = 0; ((i < entry.PaletteNum) && ((i + entry.PaletteRAMOffsetNum) < (unsigned int)16)); i++)
+    for (int i = 0; i < entry.PaletteSlotIDs.size(); i++)
     { // set palette(s) by palette data
-        unsigned int tmpPalId = i + entry.PaletteRAMOffsetNum;
+        unsigned int tmpPalId = entry.PaletteSlotIDs[i];
+        if (tmpPalId >= 16) continue;
         if (entry.palettes[tmpPalId].size())
         {
             entry.palettes[tmpPalId].clear();
         }
-        int subPalettePtr = entry.PaletteAddress + i * 32;
+        // For vanilla ROM addresses (not 0, below available space), palettes are
+        // at fixed slot-based offsets. For saved chunks (address 0 or in available
+        // space), palettes are stored contiguously in PaletteSlotIDs order.
+        int subPalettePtr;
+        if (entry.PaletteAddress >= WL4Constants::AvailableSpaceBeginningInROM || entry.PaletteAddress == 0)
+            subPalettePtr = entry.PaletteAddress + i * 32;              // saved chunk: contiguous
+        else
+            subPalettePtr = entry.PaletteAddress + tmpPalId * 32;       // vanilla ROM: slot-based offset
         unsigned short *tmpptr = (unsigned short*) (ROMUtils::ROMFileMetadata->ROMDataPtr + subPalettePtr);
         ROMUtils::LoadPalette(&(entry.palettes[tmpPalId]), tmpptr);
     }
@@ -512,15 +590,17 @@ QVector<ROMUtils::SaveData> AssortedGraphicUtils::CreateSaveData(AssortedGraphic
     QVector<ROMUtils::SaveData> result;
     if (entry.PaletteAddress >= WL4Constants::AvailableSpaceBeginningInROM || !(entry.PaletteAddress))
     {
-        unsigned int datasize = entry.PaletteNum * 16 * 2; // 16 color, 2 bytes per color
+        unsigned int palCount = entry.PaletteSlotIDs.size();
+        unsigned int datasize = palCount * 16 * 2; // 16 color, 2 bytes per color
         unsigned short *data = new unsigned short[datasize];
         memset(data, 0, datasize);
-        for(int i = 0; i < entry.PaletteNum; ++i)
+        for(unsigned int i = 0; i < palCount; ++i)
         {
+            unsigned int slotId = entry.PaletteSlotIDs[i];
             // The first color is transparent
             for(int j = 1; j < 16; ++j)
             {
-                data[16 * i + j] = ROMUtils::QRgbToData(entry.palettes[i + entry.PaletteRAMOffsetNum][j]);
+                data[16 * i + j] = ROMUtils::QRgbToData(entry.palettes[slotId][j]);
             }
         }
 

--- a/AssortedGraphicUtils.h
+++ b/AssortedGraphicUtils.h
@@ -93,7 +93,7 @@ namespace AssortedGraphicUtils
 
     // functions
     QVector<struct AssortedGraphicUtils::AssortedGraphicEntryItem> GetAssortedGraphicsFromROM();
-    void ExtractDataFromEntryInfo_v1(struct AssortedGraphicUtils::AssortedGraphicEntryItem &entry);
+    void ExtractDataFromEntryInfo_v2(struct AssortedGraphicUtils::AssortedGraphicEntryItem &entry);
     QString SaveAssortedGraphicsToROM(QVector<struct AssortedGraphicUtils::AssortedGraphicEntryItem> &entries);
 
     // savechunk relative functions

--- a/AssortedGraphicUtils.h
+++ b/AssortedGraphicUtils.h
@@ -40,8 +40,7 @@ namespace AssortedGraphicUtils
         enum AssortedGraphicMappingDataCompressionType MappingDataCompressType;
         QString MappingDataName;
         unsigned int PaletteAddress = 0;
-        unsigned int PaletteNum = 1; // when (optionalPaletteAddress + PaletteNum) > 16, we just discard the latter palettes
-        unsigned int PaletteRAMOffsetNum = 0; // unit: per palette, 16 color
+        QVector<unsigned int> PaletteSlotIDs; // individual palette slot IDs, e.g. [1, 3, 5] instead of a start+length pair
         unsigned int optionalGraphicWidth = 0; // overwrite size params when the mapping data include size info
         unsigned int optionalGraphicHeight = 0;
 
@@ -62,8 +61,7 @@ namespace AssortedGraphicUtils
             this->MappingDataCompressType = entry.MappingDataCompressType;
             this->MappingDataName = entry.MappingDataName;
             this->PaletteAddress = entry.PaletteAddress;
-            this->PaletteNum = entry.PaletteNum;
-            this->PaletteRAMOffsetNum = entry.PaletteRAMOffsetNum;
+            this->PaletteSlotIDs = entry.PaletteSlotIDs;
             this->optionalGraphicWidth = entry.optionalGraphicWidth;
             this->optionalGraphicHeight = entry.optionalGraphicHeight;
             this->tileData = entry.tileData;

--- a/Dialog/GraphicManagerDialog.cpp
+++ b/Dialog/GraphicManagerDialog.cpp
@@ -3,6 +3,7 @@
 
 #include <QMessageBox>
 #include <QModelIndex>
+#include <QSet>
 
 #include "WL4EditorWindow.h"
 #include "WL4Constants.h"
@@ -99,8 +100,8 @@ void GraphicManagerDialog::CreateAndAddDefaultEntry()
     testentry.MappingDataCompressType = AssortedGraphicUtils::AssortedGraphicMappingDataCompressionType::RLE_mappingtype_0x20;
     testentry.MappingDataName = "Layer 3";
     testentry.PaletteAddress = 0x583C7C;
-    testentry.PaletteNum = 16; // when (optionalPaletteAddress + PaletteNum) > 16, we just discard the latter palettes
-    testentry.PaletteRAMOffsetNum = 0; // unit: per palette, 16 color
+    for (unsigned int i = 0; i < 16; i++)
+        testentry.PaletteSlotIDs.push_back(i); // all 16 palette slots
     testentry.optionalGraphicWidth = 0; // overwrite size params when the mapping data include size info
     testentry.optionalGraphicHeight = 0;
 
@@ -223,10 +224,9 @@ QPixmap GraphicManagerDialog::RenderAllTiles(AssortedGraphicUtils::AssortedGraph
 
             // find a palette can be used to draw Tiles
             int paletteId = -1;
-            if (tmpEntry.PaletteNum)
+            if (tmpEntry.PaletteSlotIDs.size())
             {
-                paletteId = tmpEntry.PaletteRAMOffsetNum;
-//                paletteId = 0xF;
+                paletteId = tmpEntry.PaletteSlotIDs[0];
             }
             else
             {
@@ -393,7 +393,6 @@ void GraphicManagerDialog::ClearPalettePanel()
 
     ui->lineEdit_paletteAddress->setText("");
     ui->lineEdit_paletteNum->setText("");
-    ui->lineEdit_paletteRAMOffset->setText("");
 }
 
 /// <summary>
@@ -442,8 +441,16 @@ void GraphicManagerDialog::ClearMappingPanel()
 void GraphicManagerDialog::SetPaletteInfoGUI(AssortedGraphicUtils::AssortedGraphicEntryItem &entry)
 {
     ui->lineEdit_paletteAddress->setText(QString::number(entry.PaletteAddress, 16));
-    ui->lineEdit_paletteNum->setText(QString::number(entry.PaletteNum, 16));
-    ui->lineEdit_paletteRAMOffset->setText(QString::number(entry.PaletteRAMOffsetNum, 16));
+
+    // Build comma-separated hex string of palette slot IDs
+    QString slotIDsStr;
+    for (int i = 0; i < entry.PaletteSlotIDs.size(); i++)
+    {
+        if (i > 0) slotIDsStr += ",";
+        slotIDsStr += QString::number(entry.PaletteSlotIDs[i], 16);
+    }
+    if (slotIDsStr.isEmpty()) slotIDsStr = "0";
+    ui->lineEdit_paletteNum->setText(slotIDsStr);
 }
 
 /// <summary>
@@ -681,8 +688,8 @@ void GraphicManagerDialog::GetVanillaGraphicEntriesFromROM()
                     newentry.MappingDataName = "Layer 0 found in: " + QString::number(levelid_array[i]) + "-" +
                                                 QString::number(roomid_array[i]) + "-" + QString::number(j);
                     newentry.PaletteAddress = roomtileset->GetPaletteAddr();
-                    newentry.PaletteNum = 16;
-                    newentry.PaletteRAMOffsetNum = 0; // unit: per palette, 16 color
+                    for (unsigned int i = 0; i < 16; i++)
+                        newentry.PaletteSlotIDs.push_back(i); // initially all 16 slots
                     newentry.optionalGraphicWidth = 0; // overwrite size params when the mapping data include size info
                     newentry.optionalGraphicHeight = 0;
 
@@ -696,9 +703,9 @@ void GraphicManagerDialog::GetVanillaGraphicEntriesFromROM()
                         if (tileid != 0x3FF)
                         {
                             usingpal = (newentry.mappingData[m] & 0xF000) >> 12;
-                            newentry.PaletteAddress += usingpal * 32;
-                            newentry.PaletteNum = 1;
-                            newentry.PaletteRAMOffsetNum = usingpal;
+                            // PaletteAddress stays at base; ExtractDataFromEntryInfo_v1 handles vanilla offset
+                            newentry.PaletteSlotIDs.clear();
+                            newentry.PaletteSlotIDs.push_back(usingpal);
                             break;
                         }
                     }
@@ -750,49 +757,41 @@ void GraphicManagerDialog::GetVanillaGraphicEntriesFromROM()
                     newentry.MappingDataName = "Layer 3 found in: " + QString::number(levelid_array[i]) + "-" +
                                                 QString::number(roomid_array[i]) + "-" + QString::number(j);
                     newentry.PaletteAddress = roomtileset->GetPaletteAddr();
-                    newentry.PaletteNum = 16;
-                    newentry.PaletteRAMOffsetNum = 0; // unit: per palette, 16 color
+                    for (unsigned int i = 0; i < 16; i++)
+                        newentry.PaletteSlotIDs.push_back(i); // initially all 16 slots
                     newentry.optionalGraphicWidth = 0; // overwrite size params when the mapping data include size info
                     newentry.optionalGraphicHeight = 0;
 
                     AssortedGraphicUtils::ExtractDataFromEntryInfo_v1(newentry);
 
-                    // reset a part of palette settings for bg graphic entries
-                    int usingpal = 15;
-                    int tmpusingpal = -1;
-                    int palnum = 1;
+                    // Collect all distinct palette IDs actually used by the mapping data
+                    QSet<unsigned int> usedPaletteIDs;
                     for (int m = 0; m < newentry.mappingData.size(); m++)
                     {
                         int tileid = (newentry.mappingData[m] & 0x3FF);
                         if (tileid != 0x3FF)
                         {
-                            usingpal = (newentry.mappingData[m] & 0xF000) >> 12;
-                            if (tmpusingpal == -1)
-                            {
-                                tmpusingpal = usingpal;
-                            }
-                            else if (tmpusingpal != -1)
-                            {
-                                if (tmpusingpal == (usingpal - 1))
-                                {
-                                    palnum = 2;
-                                    usingpal = tmpusingpal;
-                                    break;
-                                }
-                                else if ((tmpusingpal - 1) == usingpal)
-                                {
-                                    palnum = 2;
-                                    break;
-                                }
-                            }
+                            unsigned int palId = (newentry.mappingData[m] & 0xF000) >> 12;
+                            usedPaletteIDs.insert(palId);
                         }
                     }
-                    newentry.PaletteAddress += usingpal * 32;
-                    newentry.PaletteNum = palnum;
-                    newentry.PaletteRAMOffsetNum = usingpal;
+
+                    // Build PaletteSlotIDs from the actually-used palette IDs (sorted)
+                    newentry.PaletteSlotIDs.clear();
+                    for (unsigned int id : usedPaletteIDs)
+                        newentry.PaletteSlotIDs.push_back(id);
+                    std::sort(newentry.PaletteSlotIDs.begin(), newentry.PaletteSlotIDs.end());
+                    if (newentry.PaletteSlotIDs.isEmpty())
+                        newentry.PaletteSlotIDs.push_back(0); // fallback
+
+                    // PaletteAddress stays at the tileset's palette base (palette 0).
+                    // ExtractDataFromEntryInfo_v1 uses tmpPalId*32 offset for vanilla ROM
+                    // addresses, so keeping the base address is correct.
+
+                    // Clear unused palettes
                     for (int i = 0; i < 16; ++i)
                     {
-                        if (palnum == 1 ? (i != usingpal) : ((i != usingpal && (i != (usingpal + 1)))))
+                        if (!usedPaletteIDs.contains(i))
                         {
                             newentry.palettes[i].clear();
                             for (int j = 0; j < 16; ++j) // (re-)initialization
@@ -913,25 +912,33 @@ void GraphicManagerDialog::on_pushButton_ImportPaletteData_clicked()
 
         // try to use the settings from the UI to import palette
         int palAddress = ui->lineEdit_paletteAddress->text().toUInt(nullptr, 16);
-        int palnum = ui->lineEdit_paletteNum->text().toUInt(nullptr, 16);
-        int paloffset = ui->lineEdit_paletteRAMOffset->text().toUInt(nullptr, 16);
+
+        // Parse palette slot IDs from the comma-separated hex field
+        QVector<unsigned int> slotIDs;
+        QStringList slotIDStrings = ui->lineEdit_paletteNum->text().split(",", Qt::SkipEmptyParts);
+        for (const QString &s : slotIDStrings)
+        {
+            bool ok;
+            unsigned int id = s.trimmed().toUInt(&ok, 16);
+            if (ok && id < 16)
+                slotIDs.push_back(id);
+        }
 
         // palAddress is not a vanilla rom address, so we need to import palette from file
         if (!palAddress || palAddress >= WL4Constants::AvailableSpaceBeginningInROM)
         {
-            if (palnum == 1) // we only import one 16-color palette
+            if (slotIDs.size() == 1) // we only import one 16-color palette
             {
                 FileIOUtils::ImportPalette(this,
                     [this] (int selectedPalId, int colorId, QRgb newColor)
                     {
                         this->tmpEntry.SetColor(selectedPalId, colorId, newColor);
                     },
-                    paloffset);
+                    slotIDs[0]);
 
                 // set tmpEntry if everything looks correct
                 tmpEntry.PaletteAddress = 0;
-                tmpEntry.PaletteNum = palnum;
-                tmpEntry.PaletteRAMOffsetNum = paloffset;
+                tmpEntry.PaletteSlotIDs = slotIDs;
             }
             else
             {
@@ -948,35 +955,25 @@ void GraphicManagerDialog::on_pushButton_ImportPaletteData_clicked()
                 QMessageBox::critical(this, tr("Error"), tr("The address has to be multiple of 4!"));
                 return;
             }
-            if ((palnum + paloffset) > 16)
+            if (slotIDs.isEmpty())
             {
-                QMessageBox::critical(this, tr("Error"), tr("The value of palnum + paloffset goes out of bound!"));
-                return;
-            }
-            if (palnum < 0)
-            {
-                QMessageBox::critical(this, tr("Error"), tr("Illegal palnum!"));
-                return;
-            }
-            if (paloffset < 0)
-            {
-                QMessageBox::critical(this, tr("Error"), tr("Illegal palnum!"));
+                QMessageBox::critical(this, tr("Error"), tr("No valid palette slot IDs specified!"));
                 return;
             }
 
-            // Load palette from the ROM
-            for (int i = 0; i < palnum; ++i)
+            // Load palette(s) from the ROM — one per slot ID, consecutive in ROM
+            for (int i = 0; i < slotIDs.size(); ++i)
             {
-                if (tmpEntry.palettes[i + paloffset].size())
-                    tmpEntry.palettes[i + paloffset].clear();
+                unsigned int slotId = slotIDs[i];
+                if (tmpEntry.palettes[slotId].size())
+                    tmpEntry.palettes[slotId].clear();
                 // First color is transparent
-                ROMUtils::LoadPalette(&(tmpEntry.palettes[i + paloffset]), (unsigned short *) (ROMUtils::ROMFileMetadata->ROMDataPtr + palAddress + i * 32));
+                ROMUtils::LoadPalette(&(tmpEntry.palettes[slotId]), (unsigned short *) (ROMUtils::ROMFileMetadata->ROMDataPtr + palAddress + i * 32));
             }
 
             // set tmpEntry if everything looks correct
             tmpEntry.PaletteAddress = palAddress;
-            tmpEntry.PaletteNum = palnum;
-            tmpEntry.PaletteRAMOffsetNum = paloffset;
+            tmpEntry.PaletteSlotIDs = slotIDs;
         }
 
         // UI reset

--- a/Dialog/GraphicManagerDialog.cpp
+++ b/Dialog/GraphicManagerDialog.cpp
@@ -105,7 +105,7 @@ void GraphicManagerDialog::CreateAndAddDefaultEntry()
     testentry.optionalGraphicWidth = 0; // overwrite size params when the mapping data include size info
     testentry.optionalGraphicHeight = 0;
 
-    AssortedGraphicUtils::ExtractDataFromEntryInfo_v1(testentry);
+    AssortedGraphicUtils::ExtractDataFromEntryInfo_v2(testentry);
     graphicEntries.append(testentry);
 }
 
@@ -762,7 +762,7 @@ void GraphicManagerDialog::GetVanillaGraphicEntriesFromROM()
                     newentry.optionalGraphicWidth = 0; // overwrite size params when the mapping data include size info
                     newentry.optionalGraphicHeight = 0;
 
-                    AssortedGraphicUtils::ExtractDataFromEntryInfo_v1(newentry);
+                    AssortedGraphicUtils::ExtractDataFromEntryInfo_v2(newentry);
 
                     // Collect all distinct palette IDs actually used by the mapping data
                     QSet<unsigned int> usedPaletteIDs;

--- a/Dialog/GraphicManagerDialog.cpp
+++ b/Dialog/GraphicManagerDialog.cpp
@@ -920,8 +920,20 @@ void GraphicManagerDialog::on_pushButton_ImportPaletteData_clicked()
         {
             bool ok;
             unsigned int id = s.trimmed().toUInt(&ok, 16);
-            if (ok && id < 16)
+            if (!ok)
+            {
+                QMessageBox::warning(this, tr("Warning"), tr("A part of text cannot be converted to palette slot ID: ") + s);
+                return;
+            }
+            else if (id >= 16)
+            {
+                QMessageBox::warning(this, tr("Warning"), tr("Palette slot ID must be between 0 and 15: ") + s);
+                return;
+            }
+            else
+            {
                 slotIDs.push_back(id);
+            }
         }
 
         // palAddress is not a vanilla rom address, so we need to import palette from file

--- a/Dialog/GraphicManagerDialog.ui
+++ b/Dialog/GraphicManagerDialog.ui
@@ -37,10 +37,10 @@
        <item>
         <widget class="QListView" name="listView_RecordGraphicsList">
          <property name="editTriggers">
-          <set>QAbstractItemView::NoEditTriggers</set>
+          <set>QAbstractItemView::EditTrigger::NoEditTriggers</set>
          </property>
          <property name="selectionMode">
-          <enum>QAbstractItemView::SingleSelection</enum>
+          <enum>QAbstractItemView::SelectionMode::SingleSelection</enum>
          </property>
         </widget>
        </item>
@@ -83,7 +83,7 @@
             <x>0</x>
             <y>0</y>
             <width>354</width>
-            <height>630</height>
+            <height>631</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -92,34 +92,12 @@
              <property name="topMargin">
               <number>0</number>
              </property>
-             <item row="0" column="1">
-              <widget class="QLabel" name="label_Tile8x8s">
+             <item row="0" column="2">
+              <widget class="QPushButton" name="pushButton_ClearTile8x8Data">
                <property name="text">
-                <string>Tile8x8s:</string>
+                <string>Clear</string>
                </property>
               </widget>
-             </item>
-             <item row="12" column="2">
-              <widget class="QLineEdit" name="lineEdit_paletteNum"/>
-             </item>
-             <item row="10" column="1" colspan="2">
-              <widget class="QGraphicsView" name="graphicsView_palettes"/>
-             </item>
-             <item row="13" column="1">
-              <widget class="QLabel" name="label_paletteRAMOffset">
-               <property name="text">
-                <string>pal RAM offset (Hex, Palette)</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="2">
-              <widget class="QLineEdit" name="lineEdit_tileDataAddress"/>
-             </item>
-             <item row="3" column="2">
-              <widget class="QLineEdit" name="lineEdit_tileDataSizeInByte"/>
-             </item>
-             <item row="5" column="2">
-              <widget class="QComboBox" name="comboBox_tileDataType"/>
              </item>
              <item row="2" column="1">
               <widget class="QLabel" name="label_tileDataAddress">
@@ -131,6 +109,9 @@
                </property>
               </widget>
              </item>
+             <item row="6" column="2">
+              <widget class="QLineEdit" name="lineEdit_tileDataName"/>
+             </item>
              <item row="6" column="1">
               <widget class="QLabel" name="label_tileDataName">
                <property name="text">
@@ -138,84 +119,49 @@
                </property>
               </widget>
              </item>
-             <item row="12" column="1">
-              <widget class="QLabel" name="label_paletteNum">
-               <property name="text">
-                <string>palette number (Hex, Palette):</string>
+             <item row="1" column="1" colspan="2">
+              <widget class="QGraphicsView" name="graphicsView_tile8x8setData"/>
+             </item>
+             <item row="10" column="1" colspan="2">
+              <widget class="QGraphicsView" name="graphicsView_palettes"/>
+             </item>
+             <item row="8" column="1" colspan="2">
+              <widget class="Line" name="line">
+               <property name="orientation">
+                <enum>Qt::Orientation::Horizontal</enum>
                </property>
               </widget>
              </item>
              <item row="4" column="2">
               <widget class="QLineEdit" name="lineEdit_tileDataRAMoffset"/>
              </item>
-             <item row="1" column="1" colspan="2">
-              <widget class="QGraphicsView" name="graphicsView_tile8x8setData"/>
+             <item row="13" column="1" colspan="2">
+              <widget class="QPushButton" name="pushButton_ImportPaletteData">
+               <property name="toolTip">
+                <string>Import from ROM or files</string>
+               </property>
+               <property name="text">
+                <string>Load palette</string>
+               </property>
+              </widget>
+             </item>
+             <item row="12" column="1">
+              <widget class="QLabel" name="label_paletteNum">
+               <property name="text">
+                <string>palette slot IDs (Hex, comma-sep):</string>
+               </property>
+              </widget>
              </item>
              <item row="11" column="2">
               <widget class="QLineEdit" name="lineEdit_paletteAddress"/>
              </item>
-             <item row="11" column="1">
-              <widget class="QLabel" name="label_paletteAddress">
-               <property name="toolTip">
-                <string>Assign an address here if you want to use vanilla palette data from the ROM. or just leave it blank.</string>
-               </property>
-               <property name="text">
-                <string>palette address (Hex):</string>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="1">
-              <widget class="QLabel" name="label_tileDataSizeInByte">
-               <property name="text">
-                <string>Tile8x8 data size (Hex, Byte):</string>
-               </property>
-              </widget>
-             </item>
-             <item row="4" column="1">
-              <widget class="QLabel" name="label_tile8x8DataRAMOffset">
-               <property name="text">
-                <string>Tile8x8 RAM offset (Hex, Tile):</string>
-               </property>
-              </widget>
-             </item>
-             <item row="6" column="2">
-              <widget class="QLineEdit" name="lineEdit_tileDataName"/>
-             </item>
-             <item row="9" column="1">
-              <widget class="QLabel" name="label_palette">
-               <property name="text">
-                <string>Palette:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="13" column="2">
-              <widget class="QLineEdit" name="lineEdit_paletteRAMOffset"/>
-             </item>
-             <item row="9" column="2">
-              <widget class="QPushButton" name="pushButton_ClearPaletteData">
-               <property name="text">
-                <string>Clear</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="2">
-              <widget class="QPushButton" name="pushButton_ClearTile8x8Data">
-               <property name="text">
-                <string>Clear</string>
-               </property>
-              </widget>
+             <item row="3" column="2">
+              <widget class="QLineEdit" name="lineEdit_tileDataSizeInByte"/>
              </item>
              <item row="5" column="1">
               <widget class="QLabel" name="label_tileDataType">
                <property name="text">
                 <string>Tile8x8 data type:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="8" column="1" colspan="2">
-              <widget class="Line" name="line">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
                </property>
               </widget>
              </item>
@@ -229,15 +175,59 @@
                </property>
               </widget>
              </item>
-             <item row="14" column="1" colspan="2">
-              <widget class="QPushButton" name="pushButton_ImportPaletteData">
-               <property name="toolTip">
-                <string>Import from ROM or files</string>
-               </property>
+             <item row="4" column="1">
+              <widget class="QLabel" name="label_tile8x8DataRAMOffset">
                <property name="text">
-                <string>Load palette</string>
+                <string>Tile8x8 RAM offset (Hex, Tile):</string>
                </property>
               </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QLabel" name="label_Tile8x8s">
+               <property name="text">
+                <string>Tile8x8s:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="9" column="1">
+              <widget class="QLabel" name="label_palette">
+               <property name="text">
+                <string>Palette:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="2">
+              <widget class="QComboBox" name="comboBox_tileDataType"/>
+             </item>
+             <item row="11" column="1">
+              <widget class="QLabel" name="label_paletteAddress">
+               <property name="toolTip">
+                <string>Assign an address here if you want to use vanilla palette data from the ROM. or just leave it blank.</string>
+               </property>
+               <property name="text">
+                <string>palette address (Hex):</string>
+               </property>
+              </widget>
+             </item>
+             <item row="9" column="2">
+              <widget class="QPushButton" name="pushButton_ClearPaletteData">
+               <property name="text">
+                <string>Clear</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="1">
+              <widget class="QLabel" name="label_tileDataSizeInByte">
+               <property name="text">
+                <string>Tile8x8 data size (Hex, Byte):</string>
+               </property>
+              </widget>
+             </item>
+             <item row="12" column="2">
+              <widget class="QLineEdit" name="lineEdit_paletteNum"/>
+             </item>
+             <item row="2" column="2">
+              <widget class="QLineEdit" name="lineEdit_tileDataAddress"/>
              </item>
             </layout>
            </item>
@@ -258,7 +248,7 @@
           <x>0</x>
           <y>0</y>
           <width>357</width>
-          <height>632</height>
+          <height>633</height>
          </rect>
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -387,7 +377,7 @@
      <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>

--- a/Dialog/TilesetEditDialog.cpp
+++ b/Dialog/TilesetEditDialog.cpp
@@ -1302,9 +1302,9 @@ void TilesetEditDialog::on_pushButton_changeBGTile8x8set_clicked()
         // check if the palettes used by bg tiles are occupied by foreground Tile16s
         QVector<int> unusedpal = FindUnusedPalettes();
         bool skipthisentry = false;
-        for (int j = 0; j < graphicEntries[i].PaletteNum; j++)
+        for (int j = 0; j < graphicEntries[i].PaletteSlotIDs.size(); j++)
         {
-            if (!unusedpal.contains(graphicEntries[i].PaletteRAMOffsetNum + j))
+            if (!unusedpal.contains(graphicEntries[i].PaletteSlotIDs[j]))
             {
                 skipthisentry = true;
                 break;
@@ -1358,13 +1358,12 @@ void TilesetEditDialog::on_pushButton_changeBGTile8x8set_clicked()
         }
 
         // Reset the palette(s) according to the entry
-        int changepalId = graphicEntries[id].PaletteRAMOffsetNum;
-        int palettenum = graphicEntries[id].PaletteNum;
-        for (int n = 0; n < palettenum; n++)
+        for (int n = 0; n < graphicEntries[id].PaletteSlotIDs.size(); n++)
         {
+            int palId = graphicEntries[id].PaletteSlotIDs[n];
             for (int i = 1; i < 16; i++)
             {
-                tmp_newTilesetPtr->SetColor(changepalId + n, i, graphicEntries[id].palettes[changepalId + n][i]);
+                tmp_newTilesetPtr->SetColor(palId, i, graphicEntries[id].palettes[palId][i]);
             }
         }
 

--- a/PatchUtils.cpp
+++ b/PatchUtils.cpp
@@ -658,7 +658,7 @@ namespace PatchUtils
                 struct PatchEntryItem entry = DeserializePatchMetadata(patchTuples.mid(i, PATCH_FIELD_COUNT));
                 if (entry.PatchType != Binary)
                 {
-                    if(!std::find_if(patchChunks.begin(), patchChunks.end(), [entry](unsigned int addr){return addr == entry.PatchAddress;}))
+                    if(std::find_if(patchChunks.begin(), patchChunks.end(), [entry](unsigned int addr){return addr == entry.PatchAddress;}) == patchChunks.end())
                     {
                         singleton->GetOutputWidgetPtr()->PrintString(QT_TR_NOOP("Corruption error: Patch chunk list entry refers to an invalid patch address: 0x") + QString::number(entry.PatchAddress, 16).toUpper());
                         continue;


### PR DESCRIPTION
- palettes serialization logic changes in Graphic Manager (you can load previous ROM project via upgrade logic on data version)
- update main.yml (seems useless but updated anyway) and a small logic fix in PatchUtils.cpp to pass the compile check before merge